### PR TITLE
Update express-vs-core.qmd

### DIFF
--- a/docs/express-vs-core.qmd
+++ b/docs/express-vs-core.qmd
@@ -109,7 +109,8 @@ You can use multiple UI objects, and they will be combined together by the frame
 #| components: [editor, viewer]
 #| layout: vertical
 # Express
-from shiny.express import reactive, render
+from shiny import reactive
+from shiny.express import render, ui 
 from datetime import datetime
 
 ui.h1("Title")


### PR DESCRIPTION
Fixes error reactive import error.

```
Error starting app!

Traceback (most recent call last):
  File "<exec>", line 379, in _start_app
  File "<exec>", line 357, in __init__
  File "/lib/python3.10/site-packages/shiny/express/_run.py", line 44, in wrap_express_app
    app_ui = run_express(file).tagify()
  File "/lib/python3.10/site-packages/shiny/express/_run.py", line 102, in run_express
    exec(
  File "/home/pyodide/app_x7uqm6vkbdy1yz4ytu34/app.py", line 2, in <module>
    from shiny.express import reactive, render
ImportError: cannot import name 'reactive' from 'shiny.express' (/lib/python3.10/site-packages/shiny/express/__init__.py) 
```